### PR TITLE
Populate r.URL.Host with the forwarded host

### DIFF
--- a/proxy_headers.go
+++ b/proxy_headers.go
@@ -54,6 +54,7 @@ func ProxyHeaders(h http.Handler) http.Handler {
 		// Set the host with the value passed by the proxy
 		if r.Header.Get(xForwardedHost) != "" {
 			r.Host = r.Header.Get(xForwardedHost)
+			r.URL.Host = r.Host
 		}
 		// Call the next handler in the chain.
 		h.ServeHTTP(w, r)

--- a/proxy_headers_test.go
+++ b/proxy_headers_test.go
@@ -79,15 +79,17 @@ func TestProxyHeaders(t *testing.T) {
 	r.Header.Set(xForwardedProto, "https")
 	r.Header.Set(xForwardedHost, "google.com")
 	var (
-		addr  string
-		proto string
-		host  string
+		addr    string
+		proto   string
+		host    string
+		URLhost string
 	)
 	ProxyHeaders(http.HandlerFunc(
 		func(w http.ResponseWriter, r *http.Request) {
 			addr = r.RemoteAddr
 			proto = r.URL.Scheme
 			host = r.Host
+			URLhost = r.URL.Host
 		})).ServeHTTP(rr, r)
 
 	if rr.Code != http.StatusOK {
@@ -107,5 +109,8 @@ func TestProxyHeaders(t *testing.T) {
 		t.Fatalf("wrong address: got %s want %s", host,
 			r.Header.Get(xForwardedHost))
 	}
-
+	if URLhost != r.Header.Get(xForwardedHost) {
+		t.Fatalf("wrong address: got %s want %s", URLhost,
+			r.Header.Get(xForwardedHost))
+	}
 }


### PR DESCRIPTION
Fixes #177 

**Summary of Changes**

1. Set `r.URL.Host` (the Host part in the request URL field) to the host forwarded by the reverse proxy in ProxyHeaders handler

(see the issue for the discussion about whether this PR should proceed)